### PR TITLE
fix offset in assignments.py

### DIFF
--- a/ssaw/assignments.py
+++ b/ssaw/assignments.py
@@ -33,7 +33,7 @@ class AssignmentsApi(HQBase):
         """
         path = self.url
         limit = 10
-        offset = 1
+        offset = 0
         total_count = 11
         params = {
             'offset': offset,


### PR DESCRIPTION
Set offset to 1 will result in incorrect number of assignments when using the get_list() method of the AssignmentsApi. Change offset to 0 will fix the problem.